### PR TITLE
Added "stopped_speaking" and removed redundant "started" and "stopped listening"

### DIFF
--- a/glados.py
+++ b/glados.py
@@ -138,7 +138,9 @@ def take_command():
 # Process the command
 def process_command(command):
 
-	if 'cancel' in command:
+	if ('cancel' in command or
+		'nevermind' in command or
+		'forget it' in command):
 		speak("Sorry.", cache=True)
 
 		# Todo: Save the used trigger audio as a negative voice sample for further learning

--- a/glados.py
+++ b/glados.py
@@ -297,9 +297,9 @@ speech = LiveSpeech(lm=False, keyphrase=os.getenv('TRIGGERWORD'), kws_threshold=
 for phrase in speech:
 	try:
 		# Listen for command
-		started_listening()
+		#started_listening()
 		command = take_command()
-		stopped_listening()
+		#stopped_listening()
 		
 		# Execute command
 		process_command(command)

--- a/gladosTTS.py
+++ b/gladosTTS.py
@@ -109,8 +109,7 @@ def speak(line, cache=False):
 			if(cache):
 				shutil.copyfile("output.wav", synthFolder+cleanTTSFile(line))
 
-	
-
+	stopped_speaking()
 	eye_position_default()
 
 


### PR DESCRIPTION
invoking "stopped_speaking"  was in a place where it was never called on an error, so added it to another place.
Is it now redundant on glados.py?

Also I removed started listening/stopped listening calls when GlaDOS is waiting for the invokation command, as it was messing with my HA scripts (restoring my led strip scene to moment before GLaDOS starts speaking stopped working as GLaDOS was replacing the scene to the moment it was listening to). A bit hard to explain...

But I understand this might interfere with @nerdaxic your ReSpeaker hardware, as I believe you want it to be in the "listening mode" by default? So if this is an issue, we might have to separate ReSpeaker and HA script calls.